### PR TITLE
chore: suppress cgo compiler related warnings

### DIFF
--- a/extism_pdk.go
+++ b/extism_pdk.go
@@ -5,6 +5,7 @@ import (
 )
 
 /*
+#cgo CFLAGS: -w
 #include "extism-pdk.h"
 */
 import "C"


### PR DESCRIPTION
Still WIP, but leaving a note for myself to pick back up:

On macos, I'm getting these build errors now:

```
# command-line-arguments
./extism_pdk.go:31:27: cannot use offset + uint64(i) (value of type uint64) as type _Ctype_ulonglong in argument to (_Cfunc_extism_load_u64)
./extism_pdk.go:32:46: cannot use x (variable of type _Ctype_ulonglong) as type uint64 in argument to binary.LittleEndian.PutUint64
./extism_pdk.go:36:34: cannot use offset + uint64(i) (value of type uint64) as type _Ctype_ulonglong in argument to (_Cfunc_extism_load_u8)
./extism_pdk.go:46:23: cannot use offset + uint64(i) (value of type uint64) as type _Ctype_ulonglong in argument to (_Cfunc_extism_store_u64)
./extism_pdk.go:51:21: cannot use offset + uint64(i) (value of type uint64) as type _Ctype_ulonglong in argument to (_Cfunc_extism_store_u8)
./extism_pdk.go:60:7: cannot use inputOffset (variable of type _Ctype_ulonglong) as type uint64 in argument to load
./extism_pdk.go:79:8: cannot use offset (variable of type _Ctype_ulonglong) as type uint64 in argument to store
./extism_pdk.go:100:8: cannot use offset (variable of type _Ctype_ulonglong) as type uint64 in argument to store
./extism_pdk.go:114:7: cannot use offset (variable of type _Ctype_ulonglong) as type uint64 in argument to load
./extism_pdk.go:133:7: cannot use offset (variable of type _Ctype_ulonglong) as type uint64 in argument to load
./extism_pdk.go:133:7: too many errors
```

There must be some inconsistency between linux/macos environments.. I'll take a note to add CI for those platforms so we catch these things!