### PR TITLE
remove strings package per issue #14

### DIFF
--- a/example/http.go
+++ b/example/http.go
@@ -7,7 +7,7 @@ import (
 //export http_get
 func http_get() int32 {
 	// create an HTTP Request (withuot relying on WASI), set headers as needed
-	req := pdk.NewHTTPRequest("GET", "https://jsonplaceholder.typicode.com/todos/1")
+	req := pdk.NewHTTPRequest(pdk.MethodGet, "https://jsonplaceholder.typicode.com/todos/1")
 	req.SetHeader("some-name", "some-value")
 	req.SetHeader("another", "again")
 	// send the request, get response back (can check status on response via res.Status())

--- a/extism_pdk.go
+++ b/extism_pdk.go
@@ -2,8 +2,6 @@ package pdk
 
 import (
 	"encoding/binary"
-	"strings"
-
 	"github.com/valyala/fastjson"
 )
 
@@ -210,8 +208,34 @@ func (r HTTPResponse) Status() uint16 {
 	return r.status
 }
 
-func NewHTTPRequest(method string, url string) *HTTPRequest {
-	return &HTTPRequest{url: url, headers: nil, method: strings.ToUpper(method), body: nil}
+type ExtismHTTPMethod int32
+
+const (
+	MethodGet ExtismHTTPMethod = iota
+	MethodHead
+	MethodPost
+	MethodPut
+	MethodPatch // RFC 5789
+	MethodDelete
+	MethodConnect
+	MethodOptions
+	MethodTrace
+)
+
+var methods = map[ExtismHTTPMethod]string{
+	MethodGet:     "GET",
+	MethodHead:    "HEAD",
+	MethodPost:    "POST",
+	MethodPut:     "PUT",
+	MethodPatch:   "PATCH",
+	MethodDelete:  "DELETE",
+	MethodConnect: "CONNECT",
+	MethodOptions: "OPTIONS",
+	MethodTrace:   "TRACE",
+}
+
+func NewHTTPRequest(method ExtismHTTPMethod, url string) *HTTPRequest {
+	return &HTTPRequest{url: url, headers: nil, method: methods[method], body: nil}
 }
 
 func (r *HTTPRequest) SetHeader(key string, value string) *HTTPRequest {

--- a/extism_pdk.go
+++ b/extism_pdk.go
@@ -212,10 +212,10 @@ func (r HTTPResponse) Status() uint16 {
 	return r.status
 }
 
-type ExtismHTTPMethod int32
+type HTTPMethod int32
 
 const (
-	MethodGet ExtismHTTPMethod = iota
+	MethodGet HTTPMethod = iota
 	MethodHead
 	MethodPost
 	MethodPut
@@ -226,7 +226,7 @@ const (
 	MethodTrace
 )
 
-var methods = map[ExtismHTTPMethod]string{
+var methods = map[HTTPMethod]string{
 	MethodGet:     "GET",
 	MethodHead:    "HEAD",
 	MethodPost:    "POST",
@@ -238,7 +238,7 @@ var methods = map[ExtismHTTPMethod]string{
 	MethodTrace:   "TRACE",
 }
 
-func NewHTTPRequest(method ExtismHTTPMethod, url string) *HTTPRequest {
+func NewHTTPRequest(method HTTPMethod, url string) *HTTPRequest {
 	return &HTTPRequest{
 		meta: HTTPRequestMeta{
 			Url:    url,


### PR DESCRIPTION
this PR removes the `strings` std package, removing all unicode tables per [#14](https://github.com/extism/go-pdk/issues/14). `strings.ToUpper()` is now replaced with an `HTTPMethod` "enum" (iota + map). This list of HTTP methods was reimplemented to prevent pulling in the entire `net/http` std package just for a few strings.