### PR TITLE
feat: add json utils to pdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,18 +116,19 @@ type Sum struct {
 //export add
 func add() int32 {
 	params := Add{}
-	err := json.Unmarshal(pdk.Input(), &params)
+	// use json input helper, which automatically unmarshals the plugin input into your struct
+	err := pdk.InputJSON(&params)
 	if err != nil {
 		pdk.SetError(err)
 		return 1
 	}
 	sum := Sum{Sum: params.A + params.B}
-	output, err := json.Marshal(sum)
+	// use json output helper, which automatically marshals your struct to the plugin output
+	output, err := pdk.OutputJSON(sum)
 	if err != nil {
 		pdk.SetError(err)
 		return 1
 	}
-	pdk.Output(output)
 	return 0
 }
 ```

--- a/example/countvowels/std_main.go
+++ b/example/countvowels/std_main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	// "fmt"
 	"strconv"
 
 	"github.com/extism/go-pdk"
@@ -13,10 +14,45 @@ import (
 // `_start` via WASI. So, `main` functions should contain the plugin behavior, that the host will
 // invoke by explicitly calling `_start`.
 func main() {
-	countVowels()
+	count_vowels()
+	count_vowels_typed()
+	count_vowels_json_output()
 }
 
-func countVowels() int32 {
+type CountVowelsInput struct {
+	Input string `json:"input"`
+}
+
+type CountVowelsOuptut struct {
+	Count  int    `json:"count"`
+	Total  int    `json:"total"`
+	Vowels string `json:"vowels"`
+}
+
+//export count_vowels_typed
+func count_vowels_typed() int32 {
+	var input CountVowelsInput
+	if err := pdk.InputJson(&input); err != nil {
+		pdk.SetError(err)
+		return -1
+	}
+
+	pdk.OutputString(input.Input)
+	return 0
+}
+
+//export count_vowels_json_output
+func count_vowels_json_output() int32 {
+	output := CountVowelsOuptut{Count: 42, Total: 2.1e7, Vowels: "aAeEiIoOuUyY"}
+	err := pdk.OutputJson(output)
+	if err != nil {
+		pdk.SetError(err)
+		return -1
+	}
+	return 0
+}
+
+func count_vowels() int32 {
 	input := pdk.Input()
 
 	count := 0

--- a/example/countvowels/std_main.go
+++ b/example/countvowels/std_main.go
@@ -32,7 +32,7 @@ type CountVowelsOuptut struct {
 //export count_vowels_typed
 func count_vowels_typed() int32 {
 	var input CountVowelsInput
-	if err := pdk.InputJson(&input); err != nil {
+	if err := pdk.InputJSON(&input); err != nil {
 		pdk.SetError(err)
 		return -1
 	}
@@ -44,7 +44,7 @@ func count_vowels_typed() int32 {
 //export count_vowels_json_output
 func count_vowels_json_output() int32 {
 	output := CountVowelsOuptut{Count: 42, Total: 2.1e7, Vowels: "aAeEiIoOuUyY"}
-	err := pdk.OutputJson(output)
+	err := pdk.OutputJSON(output)
 	if err != nil {
 		pdk.SetError(err)
 		return -1

--- a/example/countvowels/tiny_main.go
+++ b/example/countvowels/tiny_main.go
@@ -22,7 +22,7 @@ type CountVowelsOuptut struct {
 //export count_vowels_typed
 func count_vowels_typed() int32 {
 	var input CountVowelsInput
-	if err := pdk.InputJson(&input); err != nil {
+	if err := pdk.InputJSON(&input); err != nil {
 		pdk.SetError(err)
 		return -1
 	}
@@ -34,7 +34,7 @@ func count_vowels_typed() int32 {
 //export count_vowels_json_output
 func count_vowels_json_output() int32 {
 	output := CountVowelsOuptut{Count: 42, Total: 2.1e7, Vowels: "aAeEiIoOuUyY"}
-	err := pdk.OutputJson(output)
+	err := pdk.OutputJSON(output)
 	if err != nil {
 		pdk.SetError(err)
 		return -1

--- a/example/countvowels/tiny_main.go
+++ b/example/countvowels/tiny_main.go
@@ -9,6 +9,39 @@ import (
 	"github.com/extism/go-pdk"
 )
 
+type CountVowelsInput struct {
+	Input string `json:"input"`
+}
+
+type CountVowelsOuptut struct {
+	Count  int    `json:"count"`
+	Total  int    `json:"total"`
+	Vowels string `json:"vowels"`
+}
+
+//export count_vowels_typed
+func count_vowels_typed() int32 {
+	var input CountVowelsInput
+	if err := pdk.InputJson(&input); err != nil {
+		pdk.SetError(err)
+		return -1
+	}
+
+	pdk.OutputString(input.Input)
+	return 0
+}
+
+//export count_vowels_json_output
+func count_vowels_json_output() int32 {
+	output := CountVowelsOuptut{Count: 42, Total: 2.1e7, Vowels: "aAeEiIoOuUyY"}
+	err := pdk.OutputJson(output)
+	if err != nil {
+		pdk.SetError(err)
+		return -1
+	}
+	return 0
+}
+
 //export count_vowels
 func count_vowels() int32 {
 	input := pdk.Input()

--- a/extism_pdk.go
+++ b/extism_pdk.go
@@ -77,16 +77,16 @@ func Input() []byte {
 	return loadInput()
 }
 
-func JsonFrom(offset uint64, v any) error {
+func JSONFrom(offset uint64, v any) error {
 	mem := FindMemory(offset)
 	return json.Unmarshal(mem.ReadBytes(), v)
 }
 
-func InputJson(v any) error {
+func InputJSON(v any) error {
 	return json.Unmarshal(Input(), v)
 }
 
-func OutputJson(v any) error {
+func OutputJSON(v any) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err

--- a/extism_pdk.go
+++ b/extism_pdk.go
@@ -77,6 +77,25 @@ func Input() []byte {
 	return loadInput()
 }
 
+func JsonFrom(offset uint64, v any) error {
+	mem := FindMemory(offset)
+	return json.Unmarshal(mem.ReadBytes(), v)
+}
+
+func InputJson(v any) error {
+	return json.Unmarshal(Input(), v)
+}
+
+func OutputJson(v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	OutputMemory(AllocateBytes(b))
+	return nil
+}
+
 func Allocate(length int) Memory {
 	clength := uint64(length)
 	offset := extism_alloc(clength)


### PR DESCRIPTION
Added a few JSON helpers to load/return input & output as well as to convert host function call offsets into Go types via `encoding/json` functions. 

I found these to be very convenient to use when writing Go plugins. 

Note: will probably need to update the workflows on CI.