### PR TITLE
fix: retain output memory until js sdk update

### DIFF
--- a/extism_pdk.go
+++ b/extism_pdk.go
@@ -163,7 +163,8 @@ func Output(data []byte) {
 
 	store(offset, data)
 	extismOutputSet(offset, clength)
-	extismFree(offset)
+	// TODO: coordinate replacement of call to free based on SDK alignment
+	// extismFree(offset)
 }
 
 // OutputString sends the UTF-8 string `s` to the host output.


### PR DESCRIPTION
related to https://github.com/extism/js-sdk/issues/79