### PR TITLE
feat: prevent log allocation unless needed

### DIFF
--- a/env.go
+++ b/env.go
@@ -120,6 +120,17 @@ func extismHTTPRequest(request, body extismPointer) extismPointer
 //go:wasmimport extism:host/env http_status_code
 func extismHTTPStatusCode() int32
 
+// extismGetLogLevel returns the current log level set in the Extism runtime.
+//
+//go:wasmimport extism:host/env get_log_level
+func extismGetLogLevel() int32
+
+// extismLogTrace logs a "trace" string to the host from the previously-written UTF-8 string written to `offset`.
+// Note that the memory at `offset` can be immediately freed because it is immediately logged.
+//
+//go:wasmimport extism:host/env log_trace
+func extismLogTrace(offset extismPointer)
+
 // extismLogInfo logs an "info" string to the host from the previously-written UTF-8 string written to `offset`.
 // Note that the memory at `offset` can be immediately freed because it is immediately logged.
 //


### PR DESCRIPTION
Is blocked by: 
- [x] Rust SDK: https://github.com/extism/extism/pull/758
- [ ] Go SDK: https://github.com/extism/go-sdk/pull/74
- [ ] JS SDK: https://github.com/extism/js-sdk/pull/85


TODO: 
- [x] add "off" case e.g. 
```rust
if level == tracing::level_filters::LevelFilter::OFF {
        output[0] = Val::I32(i32::MAX)
...
```

Expect CI to fail as this PR includes new (unreleased) runtime functions