### PR TITLE
fix: return empty map instead of nil when initializing

### DIFF
--- a/extism_pdk.go
+++ b/extism_pdk.go
@@ -356,7 +356,7 @@ func NewHTTPRequest(method HTTPMethod, url string) *HTTPRequest {
 	return &HTTPRequest{
 		meta: HTTPRequestMeta{
 			URL:     url,
-			Headers: nil,
+			Headers: map[string]string{},
 			Method:  method.String(),
 		},
 		body: nil,


### PR DESCRIPTION
Missed one spot in the prior PR